### PR TITLE
Fixed sb math

### DIFF
--- a/BetterMath/Plugin.cs
+++ b/BetterMath/Plugin.cs
@@ -36,11 +36,16 @@ namespace discord.plugins
                     string[] mathArgs = new string[args.Length - 2];
                     Array.Copy(args, 2, mathArgs, 0, args.Length - 2);
                     string math = string.Join("", mathArgs);
-                    math = math.Replace("as", "=").Replace("in", "="); //turns 1USD as EUR into 1USD=EUR, or 1GB in KB into 1GB=KB
-                    JObject json = JObject.Parse(new WebClient().DownloadString("http://www.google.com/ig/calculator?hl=en&q=" + System.Uri.EscapeDataString(math)));
+                    math = math.Replace("as", "=").Replace("in", "=").Replace("to", "="); //turns 1USD as EUR into 1USD=EUR, 1GB in KB to 1GB=KB, etc
+                    JObject json = JObject.Parse(
+                        System.Text.RegularExpressions.Regex.Unescape( //Gets rid of the \x26 which kills the JSON parser
+                            new WebClient().DownloadString("http://www.google.com/ig/calculator?hl=en&q=" + System.Uri.EscapeDataString(math))
+                            )
+                    );
                     if (!string.IsNullOrWhiteSpace((string)json["error"]) && (string)json["error"] != "0")
                         discord.core.Discord.SendChatMessage(msg.ChatRoomID, "Cannot compute!");
-                    discord.core.Discord.SendChatMessage(msg.ChatRoomID, json["lhs"] + " = " + json["rhs"]);
+                    else
+                        discord.core.Discord.SendChatMessage(msg.ChatRoomID, json["lhs"] + " = " + System.Net.WebUtility.HtmlDecode(json["rhs"])); //Unescapes the html entities, without a reference to System.Web
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
Some google update made the conversions show fractions (for instance, when you say "1m in ft", it'd respond "1 meter = 3.2808399 feet (3 feet 3⅜ inches)"). There was an escape sequence, \x21, in front of the fraction, and the fraction was an html entity. The escape sequence caused the JSON interpreter to throw an exception.

I've included, in this pull request, a fix for both the exception and a way to decode the html entity.
